### PR TITLE
Update ruby extension to compression changes

### DIFF
--- a/include/grpc/compression_ruby.h
+++ b/include/grpc/compression_ruby.h
@@ -16,8 +16,8 @@
  *
  */
 
-#ifndef GRPC_COMPRESSION_H
-#define GRPC_COMPRESSION_H
+#ifndef GRPC_COMPRESSION_RUBY_H
+#define GRPC_COMPRESSION_RUBY_H
 
 #include <grpc/impl/codegen/port_platform.h>
 
@@ -45,4 +45,4 @@ GRPCAPI int grpc_compression_algorithm_name_ruby(
 }
 #endif
 
-#endif /* GRPC_COMPRESSION_H */
+#endif /* GRPC_COMPRESSION_RUBY_H */

--- a/src/core/lib/compression/compression_ruby.cc
+++ b/src/core/lib/compression/compression_ruby.cc
@@ -43,7 +43,7 @@ int grpc_compression_algorithm_parse_ruby(
 }
 
 int grpc_compression_algorithm_name_ruby(grpc_compression_algorithm algorithm,
-                                    const char **name) {
+                                         const char **name) {
   GRPC_API_TRACE("grpc_compression_algorithm_parse(algorithm=%d, name=%p)", 2,
                  ((int)algorithm, name));
   switch (algorithm) {

--- a/src/ruby/ext/grpc/rb_compression_options.c
+++ b/src/ruby/ext/grpc/rb_compression_options.c
@@ -23,6 +23,7 @@
 #include "rb_grpc_imports.generated.h"
 
 #include <grpc/compression.h>
+#include <grpc/compression_ruby.h>
 #include <grpc/grpc.h>
 #include <grpc/impl/codegen/compression_types.h>
 #include <grpc/impl/codegen/grpc_types.h>
@@ -174,7 +175,7 @@ void grpc_rb_compression_options_algorithm_name_to_value_internal(
   /* Raise an error if the name isn't recognized as a compression algorithm by
    * the algorithm parse function
    * in GRPC core. */
-  if (!grpc_compression_algorithm_parse(name_slice, algorithm_value)) {
+  if (!grpc_compression_algorithm_parse_ruby(name_slice, algorithm_value)) {
     tmp_str = grpc_slice_to_c_string(name_slice);
     rb_raise(rb_eNameError, "Invalid compression algorithm name: %s", tmp_str);
   }
@@ -286,7 +287,7 @@ VALUE grpc_rb_compression_options_algorithm_value_to_name_internal(
     grpc_compression_algorithm internal_value) {
   char *algorithm_name = NULL;
 
-  if (!grpc_compression_algorithm_name(internal_value, &algorithm_name)) {
+  if (!grpc_compression_algorithm_name_ruby(internal_value, &algorithm_name)) {
     rb_raise(rb_eArgError, "Failed to convert algorithm value to name");
   }
 

--- a/src/ruby/pb/test/client.rb
+++ b/src/ruby/pb/test/client.rb
@@ -102,7 +102,7 @@ def create_stub(opts)
   if ['client_compressed_unary',
       'client_compressed_streaming'].include?(opts.test_case)
     compression_options =
-      GRPC::Core::CompressionOptions.new(default_algorithm: 'message/gzip')
+      GRPC::Core::CompressionOptions.new(default_algorithm: :gzip)
     compression_channel_args = compression_options.to_channel_arg_hash
   else
     compression_channel_args = {}

--- a/src/ruby/spec/compression_options_spec.rb
+++ b/src/ruby/spec/compression_options_spec.rb
@@ -19,7 +19,7 @@ describe GRPC::Core::CompressionOptions do
   # according to what the core lib provides.
 
   # Names of supported compression algorithms
-  ALGORITHMS = [:identity, 'message/deflate', 'message/gzip']
+  ALGORITHMS = [:identity, :deflate, :gzip]
 
   # Names of valid supported compression levels
   COMPRESS_LEVELS = [:none, :low, :medium, :high]
@@ -54,10 +54,10 @@ describe GRPC::Core::CompressionOptions do
       options = GRPC::Core::CompressionOptions.new(
         default_algorithm: :identity,
         default_level: :none,
-        disabled_algorithms: ['message/gzip', 'message/deflate']
+        disabled_algorithms: [:gzip, :deflate]
       )
 
-      ['message/gzip', 'message/deflate'].each do |algorithm|
+      [:gzip, :deflate].each do |algorithm|
         expect(options.algorithm_enabled?(algorithm)).to be false
         expect(options.disabled_algorithms.include?(algorithm)).to be true
       end
@@ -69,16 +69,16 @@ describe GRPC::Core::CompressionOptions do
 
     it 'works when all optional args have been set' do
       options = GRPC::Core::CompressionOptions.new(
-        default_algorithm: 'message/gzip',
+        default_algorithm: :gzip,
         default_level: :low,
-        disabled_algorithms: ['message/deflate']
+        disabled_algorithms: [:deflate]
       )
 
-      expect(options.algorithm_enabled?('message/deflate')).to be false
-      expect(options.algorithm_enabled?('message/gzip')).to be true
-      expect(options.disabled_algorithms).to eq(['message/deflate'])
+      expect(options.algorithm_enabled?(:deflate)).to be false
+      expect(options.algorithm_enabled?(:gzip)).to be true
+      expect(options.disabled_algorithms).to eq([:deflate])
 
-      expect(options.default_algorithm).to be('message/gzip')
+      expect(options.default_algorithm).to be(:gzip)
       expect(options.default_level).to be(:low)
       expect(options.to_hash).to be_instance_of(Hash)
     end
@@ -102,12 +102,12 @@ describe GRPC::Core::CompressionOptions do
 
   describe '#new with bad parameters' do
     it 'should fail with more than one parameter' do
-      blk = proc { GRPC::Core::CompressionOptions.new('message/gzip', :none) }
+      blk = proc { GRPC::Core::CompressionOptions.new(:gzip, :none) }
       expect { blk.call }.to raise_error
     end
 
     it 'should fail with a non-hash parameter' do
-      blk = proc { GRPC::Core::CompressionOptions.new('message/gzip') }
+      blk = proc { GRPC::Core::CompressionOptions.new(:gzip) }
       expect { blk.call }.to raise_error
     end
   end
@@ -137,7 +137,7 @@ describe GRPC::Core::CompressionOptions do
     [:none, :any, 'gzip', Object.new, 1].each do |name|
       it "should fail for parameter ${name} of class #{name.class}" do
         options = GRPC::Core::CompressionOptions.new(
-          disabled_algorithms: ['message/gzip'])
+          disabled_algorithms: [:gzip])
 
         blk = proc do
           options.algorithm_enabled?(name)


### PR DESCRIPTION
this uses the new ruby-specific compression api in core and reverts the compression-related ruby tests back to as they are on master